### PR TITLE
[Draft] Handling inputs and outputs of GraphFloat32

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/inference_context.h
+++ b/tensorflow/lite/delegates/gpu/cl/inference_context.h
@@ -117,7 +117,7 @@ class InferenceContext {
   absl::Status ReserveGraphTensors(const CreateInferenceInfo& create_info,
                                    const GpuInfo& gpu_info,
                                    const GraphFloat32& graph);
-  absl::Status Merge();
+  absl::Status Merge(const GraphFloat32& graph);
   absl::Status AllocateMemory(CLContext* context);
 
   absl::Status AllocateMemoryForConstTensors(CLContext* context);

--- a/tensorflow/lite/delegates/gpu/common/model.h
+++ b/tensorflow/lite/delegates/gpu/common/model.h
@@ -103,6 +103,10 @@ class GraphFloat32 {
 
   bool IsGraphOutput(ValueId id) const;
 
+  absl::Status AddGraphInput(ValueId id);
+  
+  absl::Status AddGraphOutput(ValueId id);
+
   // @return producer of the given value. Returns nullptr for deleted value.
   Node* FindProducer(ValueId id) const;
 
@@ -181,7 +185,9 @@ class GraphFloat32 {
 
   template <typename T>
   static void Erase(std::vector<T>* values, T value) {
-    values->erase(std::find(values->begin(), values->end(), value));
+    auto it = std::find(values->begin(), values->end(), value);
+    if (it != values->end())
+      values->erase(it);
   }
 
   // @return non-nullptr NodeDef that has valid Node or an error
@@ -219,6 +225,9 @@ class GraphFloat32 {
   // unique_ptr and store it in values_ and nodes_ or store it by value.
   // We store it by value here to make introspection calls cheaper.
   std::vector<ValueDef> values_;
+
+  std::vector<ValueId> input_values_;
+  std::vector<ValueId> output_values_;
 
   std::map<NodeId, NodeDef> nodes_;
   // Node Ids in order of execution.

--- a/tensorflow/lite/delegates/gpu/common/model_builder.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder.cc
@@ -2565,12 +2565,19 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context, bool allow_quant_ops,
 absl::Status PrecreateIOTensors(
     TfLiteContext* context, GraphFloat32* graph, const std::vector<int>& io_ids,
     absl::flat_hash_map<int, int>* quant_conversion_map,
-    absl::flat_hash_map<int, Value*>* tensor_to_value) {
+    absl::flat_hash_map<int, Value*>* tensor_to_value, bool is_input) {
   for (const auto& id : io_ids) {
     const TfLiteTensor& tflite_tensor = context->tensors[id];
     if (tflite::IsConstantTensor(&tflite_tensor)) continue;
     RETURN_IF_ERROR(ObjectReader::ReadNonConstantTensor(
         context, tensor_to_value, quant_conversion_map, graph, id));
+
+    if (is_input) {
+      RETURN_IF_ERROR(graph->AddGraphInput((*tensor_to_value)[id]->id));
+    }
+    else {
+      RETURN_IF_ERROR(graph->AddGraphOutput((*tensor_to_value)[id]->id));
+    }
   }
   return absl::OkStatus();
 }
@@ -2662,9 +2669,9 @@ absl::Status BuildModelEnforceIO(
   std::vector<ValueId> variable_inputs_to_value_id;
 
   RETURN_IF_ERROR(PrecreateIOTensors(context, graph, input_ids,
-                                     quant_conversion_map, &tensor_to_value));
+                                     quant_conversion_map, &tensor_to_value, true));
   RETURN_IF_ERROR(PrecreateIOTensors(context, graph, output_ids,
-                                     quant_conversion_map, &tensor_to_value));
+                                     quant_conversion_map, &tensor_to_value, false));
   for (int i = 0; i < operations.size(); ++i) {
     TfLiteNode* tflite_node;
     TfLiteRegistration* registration;


### PR DESCRIPTION
- `GraphFloat32` is an IR(Intermediate Representation) of the network for the GPU delegates.
- Currently, when it determines the inputs of outputs of graph, it checks whether the tensor(`ValueDef`) has consumers or not.
- We need to handle inputs and output of `GraphFloat32`.